### PR TITLE
Add WebP image support with graceful fallback handling

### DIFF
--- a/src/services/ImageProcessingService.test.ts
+++ b/src/services/ImageProcessingService.test.ts
@@ -344,4 +344,36 @@ describe('ImageProcessingService', () => {
       expect(needsProcessing).toBe(true);
     });
   });
+
+  describe('WebP Fallback Handling', () => {
+    test('should return original WebP buffer when Jimp cannot decode it', async () => {
+      const { Jimp } = require('jimp');
+      Jimp.fromBuffer.mockRejectedValueOnce(
+        new Error('Could not find MIME for Buffer')
+      );
+
+      // Valid WebP magic bytes: RIFF + 4 padding bytes + WEBP
+      const webpBuffer = Buffer.concat([
+        Buffer.from('RIFF', 'ascii'),
+        Buffer.from([0x00, 0x00, 0x00, 0x00]),
+        Buffer.from('WEBP', 'ascii'),
+      ]);
+
+      const result = await service.convertToJpeg(webpBuffer);
+      expect(result.buffer).toBe(webpBuffer);
+      expect(result.backgroundProcessed).toBe(false);
+      expect(result.format).toBe('webp');
+    });
+
+    test('should process WebP files in background processing detection', async () => {
+      const webpBuffer = Buffer.concat([
+        Buffer.from('RIFF', 'ascii'),
+        Buffer.from([0x00, 0x00, 0x00, 0x00]),
+        Buffer.from('WEBP', 'ascii'),
+      ]);
+      const needsProcessing =
+        await service.needsBackgroundProcessing(webpBuffer);
+      expect(needsProcessing).toBe(true);
+    });
+  });
 });

--- a/src/services/ImageProcessingService.test.ts
+++ b/src/services/ImageProcessingService.test.ts
@@ -8,6 +8,7 @@ import {
   imageProcessor,
   ImageProcessingOptions,
 } from './ImageProcessingService';
+import { Jimp } from 'jimp';
 
 // Mock logger and error handler
 jest.mock('./LoggingService', () => ({
@@ -347,8 +348,7 @@ describe('ImageProcessingService', () => {
 
   describe('WebP Fallback Handling', () => {
     test('should return original WebP buffer when Jimp cannot decode it', async () => {
-      const { Jimp } = require('jimp');
-      Jimp.fromBuffer.mockRejectedValueOnce(
+      (Jimp.fromBuffer as jest.Mock).mockRejectedValueOnce(
         new Error('Could not find MIME for Buffer')
       );
 

--- a/src/services/ImageProcessingService.ts
+++ b/src/services/ImageProcessingService.ts
@@ -265,6 +265,23 @@ export class ImageProcessingService {
         height: originalHeight,
       };
     } catch (error) {
+      // Jimp v1.x has incomplete WebP decoder support. If a WebP image fails to
+      // load, return the original buffer so the download succeeds rather than
+      // failing the entire operation.
+      const format = this.detectImageFormat(imageBuffer);
+      if (format === 'webp') {
+        logger.warn(
+          'WebP image could not be processed by Jimp — saving original WebP buffer',
+          'ImageProcessingService',
+          { bufferSize: imageBuffer.length }
+        );
+        return {
+          buffer: imageBuffer,
+          backgroundProcessed: false,
+          format: 'webp',
+        };
+      }
+
       const processedError = errorHandler.handleError(
         error,
         'ImageProcessingService',
@@ -276,7 +293,6 @@ export class ImageProcessingService {
         'ImageProcessingService'
       );
 
-      // Throw error instead of returning original buffer (better error visibility)
       throw new Error(`Image conversion failed: ${processedError.message}`);
     }
   }

--- a/src/services/downloadService.ts
+++ b/src/services/downloadService.ts
@@ -106,14 +106,13 @@ export class DownloadService extends EventEmitter {
         { throwOnError: false }
       );
       logger.error(
-        'Advanced image processing failed, attempting basic PNG to JPEG conversion',
+        'Image processing failed',
         processedError,
         'DownloadService'
       );
 
-      // With @napi-rs/canvas, we don't need a fallback - throw error to fail download properly
       throw new Error(
-        `Cannot convert PNG to JPEG - image processing failed: ${processedError.message}`
+        `Image conversion failed: ${processedError.message}`
       );
     }
   }
@@ -289,7 +288,7 @@ export class DownloadService extends EventEmitter {
         let processedContent = content;
         let backgroundProcessed = false;
 
-        const isImageFile = /\.(jpg|jpeg|png|gif|bmp)$/i.test(url);
+        const isImageFile = /\.(jpg|jpeg|png|gif|bmp|webp)$/i.test(url);
         if (isImageFile) {
           try {
             const result = await this.convertToJpg(
@@ -387,7 +386,8 @@ export class DownloadService extends EventEmitter {
   }> {
     const headers = {
       'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      Accept: 'image/webp,image/avif,image/png,image/jpeg,image/*,*/*;q=0.8',
     };
 
     for (let attempt = 0; attempt < retryCount; attempt++) {
@@ -443,6 +443,15 @@ export class DownloadService extends EventEmitter {
           message: 'Success',
         };
       } catch (error) {
+        // 404 is permanent — skip retries immediately
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          return {
+            success: false,
+            httpStatus: 404,
+            message: 'File not found (404)',
+          };
+        }
+
         if (attempt === retryCount - 1) {
           // Last attempt failed
           if (axios.isAxiosError(error)) {
@@ -600,7 +609,7 @@ export class DownloadService extends EventEmitter {
         let processedContent = sourceResult.content;
         let backgroundProcessed = false;
 
-        const isImageFile = /\.(jpg|jpeg|png|gif|bmp)$/i.test(
+        const isImageFile = /\.(jpg|jpeg|png|gif|bmp|webp)$/i.test(
           sourceResult.filePath
         );
         if (isImageFile) {

--- a/src/services/downloadService.ts
+++ b/src/services/downloadService.ts
@@ -288,8 +288,8 @@ export class DownloadService extends EventEmitter {
         let processedContent = content;
         let backgroundProcessed = false;
 
-        const isImageFile = /\.(jpg|jpeg|png|gif|bmp|webp)$/i.test(url);
-        if (isImageFile) {
+        const shouldProcessImage = isImageFile(path.basename(safeUrl));
+        if (shouldProcessImage) {
           try {
             const result = await this.convertToJpg(
               content,
@@ -387,7 +387,7 @@ export class DownloadService extends EventEmitter {
     const headers = {
       'User-Agent':
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-      Accept: 'image/webp,image/avif,image/png,image/jpeg,image/*,*/*;q=0.8',
+      Accept: 'image/webp,image/png,image/jpeg,image/*,*/*;q=0.8',
     };
 
     for (let attempt = 0; attempt < retryCount; attempt++) {
@@ -609,10 +609,8 @@ export class DownloadService extends EventEmitter {
         let processedContent = sourceResult.content;
         let backgroundProcessed = false;
 
-        const isImageFile = /\.(jpg|jpeg|png|gif|bmp|webp)$/i.test(
-          sourceResult.filePath
-        );
-        if (isImageFile) {
+        const shouldProcessImage = isImageFile(sourceResult.filePath);
+        if (shouldProcessImage) {
           try {
             const result = await this.convertToJpg(
               sourceResult.content,


### PR DESCRIPTION
## Summary
This PR adds support for WebP image format throughout the download and image processing pipeline, with graceful fallback handling for cases where Jimp cannot decode WebP files.

## Key Changes

- **WebP Format Detection**: Updated image file detection regex in `DownloadService` to recognize `.webp` files in both the main download flow and source processing flow
- **WebP Fallback Handling**: Added graceful fallback in `ImageProcessingService.convertToJpeg()` that returns the original WebP buffer when Jimp fails to decode it, allowing downloads to succeed rather than fail
- **Improved HTTP Headers**: Enhanced User-Agent string to include Chrome version and added `Accept` header explicitly requesting WebP and other modern image formats to improve server compatibility
- **404 Handling Optimization**: Added early return for HTTP 404 responses to skip unnecessary retries on permanent failures
- **Error Message Clarity**: Simplified error messages in `DownloadService` to be more generic and less misleading about fallback behavior
- **Test Coverage**: Added comprehensive tests for WebP fallback handling in both conversion and background processing detection scenarios

## Implementation Details

The WebP fallback leverages the existing `detectImageFormat()` method to identify WebP files by their magic bytes (RIFF header + WEBP signature). When Jimp fails to process a WebP image, the service logs a warning and returns the original buffer unchanged, ensuring the download completes successfully while preserving the original image data. This approach acknowledges Jimp v1.x's incomplete WebP decoder support without blocking the entire download operation.

https://claude.ai/code/session_01UAgZdYfw7EiwkyeooVp2oJ