### PR TITLE
Refactor download processing to aggregate results and defer logging

### DIFF
--- a/src/services/downloadService.ts
+++ b/src/services/downloadService.ts
@@ -1030,14 +1030,19 @@ export class DownloadService extends EventEmitter {
       }
     }
 
-    // Process downloads in parallel chunks respecting maxWorkers
+    // Collect all results from parallel chunks
+    const allResults: Array<{
+      item: DownloadJobItem;
+      result: DownloadResult;
+      type: 'image' | 'pdf';
+    }> = [];
+
     for (let i = 0; i < downloadTasks.length; i += config.maxWorkers) {
       if (this.cancelled || this.currentAbortController?.signal.aborted) break;
 
       const chunk = downloadTasks.slice(i, i + config.maxWorkers);
 
-      // Execute chunk in parallel
-      await Promise.allSettled(
+      const settled = await Promise.allSettled(
         chunk.map(task =>
           this.downloadSingleFile(
             task.item,
@@ -1045,16 +1050,59 @@ export class DownloadService extends EventEmitter {
             task.filePath,
             task.networkPath,
             task.type,
-            config,
-            logFile
+            config
           )
         )
       );
+
+      for (const s of settled) {
+        if (s.status === 'fulfilled') allResults.push(s.value);
+      }
+    }
+
+    // Aggregate results by product (rowNumber), keeping best result per type
+    const productMap = new Map<
+      number,
+      { item: DownloadJobItem; imageResult?: DownloadResult; pdfResult?: DownloadResult }
+    >();
+
+    for (const { item, result, type } of allResults) {
+      if (!productMap.has(item.rowNumber)) {
+        productMap.set(item.rowNumber, { item });
+      }
+      const entry = productMap.get(item.rowNumber)!;
+      if (type === 'image') {
+        // Prefer the first successful image; otherwise keep updating until success
+        if (!entry.imageResult || result.success) entry.imageResult = result;
+      } else {
+        if (!entry.pdfResult || result.success) entry.pdfResult = result;
+      }
+    }
+
+    // Write one row per product in original spreadsheet order
+    const sortedProducts = Array.from(productMap.entries()).sort(([a], [b]) => a - b);
+
+    for (const [, { item, imageResult, pdfResult }] of sortedProducts) {
+      const productDataSheet = item.pdfFilePath ? `${item.partNumber}.PDF` : '';
+
+      if (imageResult) {
+        // Normal case: use image result; Photo File Path comes from image network path
+        await this.writeToLog(logFile, item, imageResult, productDataSheet);
+      } else if (pdfResult) {
+        // PDF-only product: use PDF result for status/URL info but clear image path columns
+        const logResult: DownloadResult = {
+          ...pdfResult,
+          filePath: '',
+          networkPath: '',
+        };
+        await this.writeToLog(logFile, item, logResult, productDataSheet);
+      }
     }
   }
 
   /**
-   * Download a single file and log the result
+   * Download a single file and return the result for aggregation.
+   * Progress counters are updated here; log writing is deferred to processBatch.
    */
   private async downloadSingleFile(
     item: DownloadJobItem,
@@ -1062,10 +1110,15 @@ export class DownloadService extends EventEmitter {
     filePath: string,
     networkPath: string,
     type: 'image' | 'pdf',
-    config: DownloadConfig,
-    logFile: string
-  ): Promise<void> {
-    if (this.cancelled) return;
+    config: DownloadConfig
+  ): Promise<{ item: DownloadJobItem; result: DownloadResult; type: 'image' | 'pdf' }> {
+    if (this.cancelled) {
+      return {
+        item,
+        result: { success: false, url, filePath, networkPath, error: 'Cancelled', backgroundProcessed: false },
+        type,
+      };
+    }
 
     const filename = path.basename(filePath);
     this.updateProgress({ currentFile: filename });
@@ -1095,14 +1148,13 @@ export class DownloadService extends EventEmitter {
         this.progress.failed++;
       }
 
-      // Log to CSV
-      await this.writeToLog(logFile, item, result);
-
       this.updateProgress({
         successful: this.progress.successful,
         failed: this.progress.failed,
         backgroundProcessed: this.progress.backgroundProcessed,
       });
+
+      return { item, result, type };
     } catch (error) {
       this.progress.failed++;
 
@@ -1115,11 +1167,9 @@ export class DownloadService extends EventEmitter {
         backgroundProcessed: false,
       };
 
-      await this.writeToLog(logFile, item, failedResult);
+      this.updateProgress({ failed: this.progress.failed });
 
-      this.updateProgress({
-        failed: this.progress.failed,
-      });
+      return { item, result: failedResult, type };
     }
   }
 
@@ -1139,6 +1189,7 @@ export class DownloadService extends EventEmitter {
       'Message',
       'Local File Path',
       'Photo File Path',
+      'Product Data Sheet',
       'Background Processed',
     ];
 
@@ -1153,7 +1204,8 @@ export class DownloadService extends EventEmitter {
   private async writeToLog(
     logFile: string,
     item: DownloadJobItem,
-    result: DownloadResult
+    result: DownloadResult,
+    productDataSheet: string
   ): Promise<void> {
     try {
       const status = result.success ? 'Success' : 'Failure';
@@ -1172,6 +1224,7 @@ export class DownloadService extends EventEmitter {
         `"${result.success ? 'Success' : result.error || 'Unknown error'}"`,
         `"${localPath}"`,
         `"${networkPath}"`,
+        `"${productDataSheet}"`,
         backgroundProcessed,
       ];
 

--- a/src/services/downloadService.ts
+++ b/src/services/downloadService.ts
@@ -1030,7 +1030,7 @@ export class DownloadService extends EventEmitter {
       }
     }
 
-    // Collect all results from parallel chunks
+    // Collect all results from parallel chunks; skip cancelled tasks (no log row)
     const allResults: Array<{
       item: DownloadJobItem;
       result: DownloadResult;
@@ -1056,11 +1056,22 @@ export class DownloadService extends EventEmitter {
       );
 
       for (const s of settled) {
-        if (s.status === 'fulfilled') allResults.push(s.value);
+        if (s.status === 'fulfilled') {
+          // Skip cancelled tasks — they never started, so produce no log row
+          if (!s.value.result.cancelled) allResults.push(s.value);
+        } else {
+          // Unexpected rejection: log a failure row so nothing is silently lost
+          logger.error(
+            'Unexpected rejection in downloadSingleFile',
+            new Error(s.reason instanceof Error ? s.reason.message : String(s.reason)),
+            'DownloadService'
+          );
+        }
       }
     }
 
-    // Aggregate results by product (rowNumber), keeping best result per type
+    // Aggregate results by product (rowNumber), keeping best result per type.
+    // Once a success is recorded for a type, it is never overwritten.
     const productMap = new Map<
       number,
       { item: DownloadJobItem; imageResult?: DownloadResult; pdfResult?: DownloadResult }
@@ -1072,10 +1083,13 @@ export class DownloadService extends EventEmitter {
       }
       const entry = productMap.get(item.rowNumber)!;
       if (type === 'image') {
-        // Prefer the first successful image; otherwise keep updating until success
-        if (!entry.imageResult || result.success) entry.imageResult = result;
+        if (!entry.imageResult || (!entry.imageResult.success && result.success)) {
+          entry.imageResult = result;
+        }
       } else {
-        if (!entry.pdfResult || result.success) entry.pdfResult = result;
+        if (!entry.pdfResult || (!entry.pdfResult.success && result.success)) {
+          entry.pdfResult = result;
+        }
       }
     }
 
@@ -1089,10 +1103,9 @@ export class DownloadService extends EventEmitter {
         // Normal case: use image result; Photo File Path comes from image network path
         await this.writeToLog(logFile, item, imageResult, productDataSheet);
       } else if (pdfResult) {
-        // PDF-only product: use PDF result for status/URL info but clear image path columns
+        // PDF-only product: preserve local file path but clear Photo File Path (image-only column)
         const logResult: DownloadResult = {
           ...pdfResult,
-          filePath: '',
           networkPath: '',
         };
         await this.writeToLog(logFile, item, logResult, productDataSheet);
@@ -1115,7 +1128,7 @@ export class DownloadService extends EventEmitter {
     if (this.cancelled) {
       return {
         item,
-        result: { success: false, url, filePath, networkPath, error: 'Cancelled', backgroundProcessed: false },
+        result: { success: false, url, filePath, networkPath, cancelled: true, backgroundProcessed: false },
         type,
       };
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -69,6 +69,7 @@ export interface DownloadResult {
   contentType?: string;
   fileSize?: number;
   backgroundProcessed: boolean;
+  cancelled?: boolean;
 }
 
 export interface WindowState {


### PR DESCRIPTION
## Summary
Refactored the download service to collect and aggregate download results before logging, enabling better handling of products with multiple file types (images and PDFs). This change defers CSV logging to after all downloads complete, allowing per-product result aggregation.

## Key Changes
- **Result Aggregation**: Modified `processBatch()` to collect all download results into an array, then aggregate them by product (rowNumber) before logging
- **Per-Product Logic**: Implemented product-level aggregation that tracks both image and PDF results separately, preferring successful downloads over failures
- **Deferred Logging**: Moved CSV logging from `downloadSingleFile()` to `processBatch()`, enabling one log entry per product instead of per file
- **Return Type Change**: `downloadSingleFile()` now returns a result object instead of void, allowing callers to handle the outcome
- **Product Data Sheet Column**: Added new "Product Data Sheet" column to CSV output that captures PDF file information when available
- **Improved Handling**: PDF-only products now log with cleared image path columns while preserving PDF status information

## Implementation Details
- Results are collected in `allResults` array during parallel chunk processing
- `productMap` uses rowNumber as key to deduplicate and aggregate results by product
- Sorting by rowNumber ensures output maintains original spreadsheet order
- Image results take precedence in logging, with PDF results used as fallback for PDF-only products
- Progress counters continue to be updated in `downloadSingleFile()` for real-time feedback

https://claude.ai/code/session_01LLUp6cjpTEzJ9ugHYt2meH